### PR TITLE
Stick post header

### DIFF
--- a/src/components/Post.css
+++ b/src/components/Post.css
@@ -3,35 +3,53 @@
   position: relative;
   padding-bottom: 20px;
   min-height: 144px; }
-  .Post:before {
-    position: absolute;
-    content: '';
-    left: 32px;
-    top: 70px;
-    height: 40px;
-    width: 40px;
-    border-radius: 0 0 0 40px;
-    border-left: 5px solid #F1F2EE;
-    border-bottom: 5px solid #F1F2EE; }
-  .Post:after {
-    position: absolute;
-    content: '';
-    left: 32px;
-    bottom: 0px;
-    height: 40px;
-    width: 40px;
-    border-radius: 40px 0 0 0;
-    border-top: 5px solid #F1F2EE;
-    border-left: 5px solid #F1F2EE; }
-  .Post > div > .Avatar {
-    margin-right: 30px; }
-  .Post > div > .body {
-    flex-direction: column; }
-    .Post > div > .body > h2 {
-      margin-bottom: 0; }
-    .Post > div > .body > .date {
-      margin-bottom: 15px;
-      color: #bbb;
-      font-size: 11.5px; }
-  .Post .CommentsList {
-    margin-left: 75px; }
+
+.Post:before {
+  position: absolute;
+  content: '';
+  left: 32px;
+  top: 70px;
+  height: 40px;
+  width: 40px;
+  border-radius: 0 0 0 40px;
+  border-left: 5px solid #F1F2EE;
+  border-bottom: 5px solid #F1F2EE; }
+
+.Post:after {
+  position: absolute;
+  content: '';
+  left: 32px;
+  bottom: 0px;
+  height: 40px;
+  width: 40px;
+  border-radius: 40px 0 0 0;
+  border-top: 5px solid #F1F2EE;
+  border-left: 5px solid #F1F2EE; }
+
+.Post > header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  margin-top: -15px;
+  padding: 15px 0;
+  background: #fff;
+  display: flex; }
+
+.Post > header > .Avatar {
+  margin-right: 30px; }
+
+.Post > header > div {
+  flex-direction: column; }
+
+.Post > header > div > h2 {
+  margin-bottom: 0; }
+
+.Post > header > div > .date {
+  color: #bbb;
+  font-size: 11.5px; }
+
+.Post > .PostContent {
+  margin-left: 100px; }
+
+.Post .CommentsList {
+  margin-left: 75px; }

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -15,19 +15,19 @@ export default function Post(
 ) {
 	return (
 		<div className="Post">
-			<div>
+			<header>
 				<Avatar
 					url={props.author ? props.author.avatar_urls['96'] : ''}
 					size={70}
 				/>
-				<div className="body">
+				<div>
 					<h2 dangerouslySetInnerHTML={{ __html: props.post.title.rendered }} />
 					<div className="date">
 						<FormattedRelative value={props.post.date_gmt} />
 					</div>
-					<PostContent html={props.post.content.rendered} />
 				</div>
-			</div>
+			</header>
+			<PostContent html={props.post.content.rendered} />
 			{props.children}
 		</div>
 	);

--- a/src/components/Post.scss
+++ b/src/components/Post.scss
@@ -25,20 +25,35 @@
 		border-top: 5px solid #F1F2EE;
 		border-left: 5px solid #F1F2EE;
 	}
-	> div > .Avatar {
-		margin-right: 30px;
-	}
-	> div > .body {
-		flex-direction: column;
+	> header {
+		// Stick on scroll.
+		position: sticky;
+		top: 0;
 
-		> h2 {
-			margin-bottom: 0;
+		// Force appearing above comments.
+		z-index: 1;
+
+		// Adjust sizing.
+		margin-top: -15px;
+		padding: 15px 0;
+		background: #fff;
+		display: flex;
+		> .Avatar {
+			margin-right: 30px;
 		}
-		> .date {
-			margin-bottom: 15px;
-			color: #bbb;
-			font-size: 11.5px;
+		> div {
+			flex-direction: column;
+			> h2 {
+				margin-bottom: 0;
+			}
+			> .date {
+				color: #bbb;
+				font-size: 11.5px;
+			}
 		}
+	}
+	> .PostContent {
+		margin-left: 100px;
 	}
 
 	.CommentsList {


### PR DESCRIPTION
![h2-sticky](https://cloud.githubusercontent.com/assets/21655/26292605/94da15d6-3efa-11e7-8209-e2a072228ccc.gif)

This uses `position: sticky` for the post header, allowing you to see the post title even when you're 400 comments deep.

By itself, this isn't particularly exciting, however adding actions to the header makes it much more useful (not included in this PR):
<img width="841" alt="screenshot 2017-05-22 14 30 50" src="https://cloud.githubusercontent.com/assets/21655/26292678/472ad298-3efb-11e7-8230-d3d5b60198bd.png">
