### PR TITLE
Fix Button's proptypes

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -15,6 +15,6 @@ export default function Button( props ) {
 
 Button.propTypes = {
 	children: PropTypes.any,
-	submit: PropTypes.bool.isRequired,
+	submit: PropTypes.bool,
 	onClick: PropTypes.func,
 };


### PR DESCRIPTION
We're only using the `submit` property to determine which `type` attribute (submit, button) should be added to the button element.