### PR TITLE
Tweak reaction styles

### DIFF
--- a/src/components/Reactions.css
+++ b/src/components/Reactions.css
@@ -12,6 +12,10 @@
 	position: relative;
 }
 
+.reactions .reactions-new {
+	opacity: 0.4;
+}
+
 .reactions .emoji-mart {
 	position: absolute;
 	top: 100%;

--- a/src/components/Reactions.js
+++ b/src/components/Reactions.js
@@ -42,7 +42,7 @@ export default class Reaction extends Component {
 				})}
 			</div>
 			<button
-				className="btn btn--small btn--tertiary"
+				className="reactions-new btn btn--small btn--tertiary"
 				onClick={ value => this.setState({ isOpen: ! this.state.isOpen  } ) }
 				key="button"
 				title="Add reaction"


### PR DESCRIPTION
| Current | New |
| -- | -- |
|  <img width="205" alt="screen shot 2017-10-17 at 19 18 32" src="https://user-images.githubusercontent.com/21655/31679463-70f905fa-b371-11e7-9f39-3edea9f976f6.png">  |  <img width="123" alt="screen shot 2017-10-17 at 19 22 34" src="https://user-images.githubusercontent.com/21655/31679476-7a38dd3e-b371-11e7-96db-8e3e287ad865.png">  |

@sambulance @mattheu We were also thinking the border could use some toning down on the regular ones to be less of a hard style (maybe for tertiary small buttons), but that's a pattern library thing.