### PR TITLE
Support cookie auth if available.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,5 @@
-import api from 'wordpress-rest-api-oauth-2';
+import oauth2Api from 'wordpress-rest-api-oauth-2';
+import cookieAuthApi from './wordpress-rest-api-cookie-auth';
 
 const url = window.location.href.split( '?' )[0];
 let config = {
@@ -13,11 +14,14 @@ if ( process.env.NODE_ENV === 'development' ) {
 	config.credentials = { client: { id: 'b73rv7has0q2' } };
 }
 
+let api = oauth2Api;
+
 if ( window.wpApiSettings ) {
 	config = {
-		rest_url: window.wpApiSettings.root,
-		nonce:    window.wpApiSettings.nonce,
+		rest_url:    window.wpApiSettings.root,
+		credentials: { nonce: window.wpApiSettings.nonce },
 	};
+	api = cookieAuthApi;
 }
 
 export default new api( config );


### PR DESCRIPTION
Not sure if this is the best way, but we can support cookie auth like so, which will automatically pick up wpApiSettings.nonce etc when the data is there.