### PR TITLE
Fix timezone parsing on post date

### DIFF
--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -58,7 +58,7 @@ class Post extends Component {
 					</Link>
 					<span className="date">
 						{author ? <AuthorName user={ author } /> : ''},&nbsp;
-						<FormattedRelative value={post.date_gmt} />
+						<FormattedRelative value={post.date_gmt + 'Z'} />
 					</span>
 					{categories.length > 0 &&
 						<ul className="categories">


### PR DESCRIPTION
Need to add a `Z` to make the date string be interpretted as UTC, not local.