### PR TITLE
CSS tweaks to improve info density a bit.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,3 +18,7 @@
 	flex-direction: column;
 	max-width: 1200px;
 }
+
+.App a {
+	border: none;
+}

--- a/src/components/Post.css
+++ b/src/components/Post.css
@@ -50,6 +50,7 @@
 .Post > header > .byline > a > h2 {
 	margin: 0 0.5em 0 0;
 	text-overflow: ellipsis;
+	text-transform: inherit;
 	white-space: nowrap;
 	overflow: hidden;
 }

--- a/src/components/PostContent.css
+++ b/src/components/PostContent.css
@@ -31,6 +31,13 @@
 	margin-right: auto;
 }
 
+.PostContent blockquote {
+	font-size: inherit;
+	border-left: 6px solid #f5f5f5;
+	color: #847F7F;
+	padding-left: 15px;
+}
+
 .PostContent > *:first-child {
 	margin-top: 0;
 }

--- a/src/components/PostsList.css
+++ b/src/components/PostsList.css
@@ -12,7 +12,7 @@
 }
 
 .PostsList:first-child {
-	padding-top: 100px;
+	padding-top: 60px;
 }
 
 .PostsList:before {
@@ -20,7 +20,7 @@
 	content: '';
 	background: #F1F2EE;
 	left: 48.5px;
-	height: 100px;
+	height: 60px;
 	top: 0;
 	width: 5px;
 	z-index: 2;

--- a/src/components/WriteComment.css
+++ b/src/components/WriteComment.css
@@ -7,7 +7,7 @@
 }
 
 .WriteComment > header > .Avatar {
-	margin-right: 10px;
+	margin-right: 20px;
 }
 
 .WriteComment .buttons {

--- a/src/components/WritePost.css
+++ b/src/components/WritePost.css
@@ -62,5 +62,5 @@
 }
 
 .WritePost > .Editor {
-	margin-left: 100px;
+	margin-left: 90px;
 }

--- a/src/components/WritePost.js
+++ b/src/components/WritePost.js
@@ -61,7 +61,7 @@ export class WritePost extends Component {
 			<header>
 				<Avatar
 					url={user ? user.avatar_urls['96'] : ''}
-					size={70}
+					size={60}
 				/>
 				<div className="byline">
 					<h2><input type="text" placeholder="Enter post title..." value={ this.state.title } onChange={ e => this.setState( { title: e.target.value } ) } /></h2>


### PR DESCRIPTION
- Remove border from `<a>` as it gets applied to images etc which we don't want.
- Reduce super-large `<blockquote>` as for conversations it doesn't make sense to use the large pull style.
- Lowercase titles, again for readability in the context of small posts uppercase doesn't make sense.
- Fix some unaligned image sizes.

Before:

![](http://joehoyle-captured.s3.amazonaws.com/gNu90ep4.png)

After:

![](http://joehoyle-captured.s3.amazonaws.com/fUGZx0Wl.png)