### PR TITLE
Fix clicking user avatar

### DIFF
--- a/src/components/Avatar.css
+++ b/src/components/Avatar.css
@@ -8,6 +8,10 @@
 	background-color: #FFF;
 }
 
+.Avatar a:hover {
+	border: none;
+}
+
 .Avatar:after {
 	content: ' ';
 	display: block;
@@ -19,4 +23,5 @@
 	position: absolute;
 	top: 0;
 	left: 0;
+	pointer-events: none;
 }


### PR DESCRIPTION
Was getting cought by the :after element, and getting an underline before.