### PR TITLE
Explicitly specify "h2" as script handle

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,9 +25,9 @@ register_sidebar( [
 ] );
 
 function enqueue_assets() {
-	ReactWPScripts\enqueue_assets( get_stylesheet_directory(), array(
+	ReactWPScripts\enqueue_assets( get_stylesheet_directory(), [
 		'handle' => 'h2'
-	) );
+	] );
 	wp_localize_script( 'h2', 'wpApiSettings', array(
 		'root'          => esc_url_raw( get_rest_url() ),
 		'nonce'         => ( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),


### PR DESCRIPTION
This project will not load properly if the repo is cloned as-is (with the capitalized "H2") because it reads the script handle from the theme directory's name. Since we manually use "h2" as the handle for script localization, specifying that same identifier manually ensures the theme will run wherever it is deployed.