### PR TITLE
Expand README setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone --recursive git@github.com:humanmade/H2.git h2
 
 Once the checkout is complete, `cd` into the cloned theme directory, install npm modules, and start the development server:
 ```
-npm i
+npm install
 npm start
 ```
 


### PR DESCRIPTION
Nothing critical, but this PR contains a few README changes around the setup process where I thought people might get tripped up in the future.

- Remove no-longer-relevant API endpoint configuration comment
- Use npm consistently, as it's still more prevalent; nothing against yarn, but if you use it, chances are good you know how to map the commands to yarn's equivalent (and the reverse isn't always true)
- Explain the need for SCRIPT_DEBUG to avoid setup confusion
- Expand local setup instructions