### PR TITLE
Warn the user if they leave while editor is open

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -91,7 +91,7 @@ export default class Editor extends React.PureComponent {
 
 		const warning = 'You have unsaved content. Are you sure you want to leave?';
 		e.returnValue = warning;
-		return e;
+		return warning;
 	}
 
 	componentDidUpdate() {


### PR DESCRIPTION
Warns the user if they attempt to leave the page while the editor is open (and they've edited the text).

(The warning message text isn't used by most modern browsers, but we need a value anyway.)

Fixes #211.