### PR TITLE
Allow list counters to overflow from content

### DIFF
--- a/src/components/Message/Content.css
+++ b/src/components/Message/Content.css
@@ -2,7 +2,6 @@
 	display: block;
 	word-wrap: break-word;
 	word-break: break-word;
-	overflow: auto;
 }
 
 .PostContent img {


### PR DESCRIPTION
This rule doesn't appear to be necessary, as elements that would overflow (long text or images) are already accounted for.

Fixes #198.