### PR TITLE
Add linter configuration

### DIFF
--- a/.github/hmlinter.yml
+++ b/.github/hmlinter.yml
@@ -1,1 +1,9 @@
 version: 0.4.2
+
+phpcs:
+    enabled: true
+    version: inherit
+
+eslint:
+    enabled: true
+    version: inherit


### PR DESCRIPTION
Fix linter configuration to 0.4.2, to avoid needing to update all the JSX at once.