### PR TITLE
Ensure selection is cleared when no longer needed

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -236,6 +236,7 @@ export default class Editor extends React.PureComponent {
 					this.textarea.selectionStart = selectionStart;
 					this.textarea.selectionEnd = selectionEnd;
 					this.focus();
+					this.setState( { lastSelection: null } );
 				}
 			}
 		);


### PR DESCRIPTION
I assumed this would be handled by onFocus, but that doesn't occur if you use the keyboard shortcuts. :grimacing:

Introduced in #231. h/t @lachlanj for mentioning this