### PR TITLE
Store post view in Redux store

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6,6 +6,7 @@ export const SHOW_SUPER_SIDEBAR = 'SHOW_SUPER_SIDEBAR';
 export const HIDE_SUPER_SIDEBAR = 'HIDE_SUPER_SIDEBAR';
 export const ENABLE_BETA_FEATURE = 'ENABLE_BETA_FEATURE';
 export const DISABLE_BETA_FEATURE = 'DISABLE_BETA_FEATURE';
+export const SET_DEFAULT_POST_VIEW = 'SET_DEFAULT_POST_VIEW';
 
 export const showSidebarProfile = id => {
 	return {
@@ -28,4 +29,9 @@ export const enableBetaFeature = feature => ( {
 export const disableBetaFeature = feature => ( {
 	type: DISABLE_BETA_FEATURE,
 	feature,
+} );
+
+export const setDefaultPostView = view => ( {
+	type: SET_DEFAULT_POST_VIEW,
+	view,
 } );

--- a/src/components/Post/List.js
+++ b/src/components/Post/List.js
@@ -6,20 +6,14 @@ import qs from 'qs';
 
 import Button from '../Button';
 import PostComponent from './index';
+import { setDefaultPostView } from '../../actions';
 import { withApiData } from '../../with-api-data';
 
 import './List.css';
 
 class PostsList extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			view: 'expanded',
-		};
-	}
-
 	render() {
+		const { defaultPostView, summaryEnabled } = this.props;
 		const { page } = this.props.match.params;
 
 		return (
@@ -27,17 +21,17 @@ class PostsList extends Component {
 				{ this.props.posts.isLoading &&
 					<ContentLoader type="list" width={ 300 } />
 				}
-				{ this.props.summaryEnabled ? (
+				{ summaryEnabled ? (
 					<div className="PostsList--settings">
 						<Button
-							disabled={ this.state.view === 'summary' }
-							onClick={ () => this.setState( { view: 'summary' } ) }
+							disabled={ defaultPostView === 'summary' }
+							onClick={ () => this.props.setDefaultPostView( 'summary' ) }
 						>
 							Summary
 						</Button>
 						<Button
-							disabled={ this.state.view === 'expanded' }
-							onClick={ () => this.setState( { view: 'expanded' } ) }
+							disabled={ defaultPostView === 'expanded' }
+							onClick={ () => this.props.setDefaultPostView( 'expanded' ) }
 						>
 							Expanded
 						</Button>
@@ -51,7 +45,7 @@ class PostsList extends Component {
 						<PostComponent
 							key={ post.id }
 							data={ post }
-							expanded={ this.state.view === 'expanded' }
+							expanded={ ! summaryEnabled || defaultPostView === 'expanded' }
 							onInvalidate={ () => this.props.invalidateData() }
 						/>
 					) )
@@ -72,10 +66,15 @@ class PostsList extends Component {
 }
 
 const mapStateToProps = state => ( {
+	defaultPostView: state.ui.defaultPostView,
 	summaryEnabled: state.features.summary_view,
 } );
 
-export default connect( mapStateToProps )( withApiData( props => ( {
+const mapDispatchToProps = dispatch => ( {
+	setDefaultPostView: view => dispatch( setDefaultPostView( view ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( withApiData( props => ( {
 	categories: props.match.params.categorySlug ? '/wp/v2/categories' : null,
 	users: props.match.params.authorSlug ? '/wp/v2/users?per_page=100' : null,
 } ) )( withApiData( props => {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -4,9 +4,11 @@ import {
 	HIDE_SIDEBAR_PROFILE,
 	SHOW_SUPER_SIDEBAR,
 	HIDE_SUPER_SIDEBAR,
+	SET_DEFAULT_POST_VIEW,
 } from '../actions';
 
 const DEFAULT_STATE = {
+	defaultPostView: 'expanded',
 	showingSuper: false,
 	sidebarProfile: null,
 };
@@ -43,6 +45,12 @@ export default function ui( state = DEFAULT_STATE, action ) {
 			return {
 				...state,
 				showingSuper: false,
+			};
+
+		case SET_DEFAULT_POST_VIEW:
+			return {
+				...state,
+				defaultPostView: action.view,
 			};
 
 		default:


### PR DESCRIPTION
This ensures it persists across route changes, although is not saved across page reloads.

Fixes #237.