### PR TITLE
Dynamically set the page title

### DIFF
--- a/src/components/PageTitle.js
+++ b/src/components/PageTitle.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import withSideEffect from 'react-side-effect';
+
+const SITE_NAME = window.H2Data.site.name;
+
+class PageTitle extends React.Component {
+	render() {
+		if ( this.props.children ) {
+			return React.Children.only( this.props.children );
+		} else {
+			return null;
+		}
+	}
+}
+
+PageTitle.propTypes = {
+	title: PropTypes.string,
+};
+
+const reducePropsToState = propsList => {
+	const innermostProps = propsList[ propsList.length - 1 ];
+	if ( innermostProps ) {
+		return innermostProps.title;
+	}
+}
+
+const handleChange = title => {
+	document.title = title ? `${ title } - ${ SITE_NAME }` : SITE_NAME;
+};
+
+export default withSideEffect(
+	reducePropsToState,
+	handleChange
+)( PageTitle );

--- a/src/components/Post/List.js
+++ b/src/components/Post/List.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import qs from 'qs';
 
 import Button from '../Button';
+import PageTitle from '../PageTitle';
 import PostComponent from './index';
 import { setDefaultPostView } from '../../actions';
 import { withApiData } from '../../with-api-data';
@@ -16,51 +17,75 @@ class PostsList extends Component {
 		const { defaultPostView, summaryEnabled } = this.props;
 		const { page } = this.props.match.params;
 
+		const isSingular = !! this.props.match.params.slug;
+		const getTitle = () => {
+			if ( this.props.match.params.search ) {
+				return `Search Results for “${ this.props.match.params.search }”`;
+			}
+
+			if ( ! isSingular ) {
+				// Use default title.
+				return null;
+			}
+
+			if ( this.props.posts.isLoading ) {
+				return 'Loading…';
+			}
+
+			if ( ! this.props.posts.data || ! this.props.posts.data[0] ) {
+				return 'Not Found';
+			}
+
+			return this.props.posts.data[0].title.rendered;
+		}
+
 		return (
-			<div className="PostsList">
-				{ this.props.posts.isLoading &&
-					<ContentLoader type="list" width={ 300 } />
-				}
-				{ summaryEnabled ? (
-					<div className="PostsList--settings">
-						<Button
-							disabled={ defaultPostView === 'summary' }
-							onClick={ () => this.props.setDefaultPostView( 'summary' ) }
-						>
-							Summary
-						</Button>
-						<Button
-							disabled={ defaultPostView === 'expanded' }
-							onClick={ () => this.props.setDefaultPostView( 'expanded' ) }
-						>
-							Expanded
-						</Button>
-					</div>
-				) : (
-					/* Dummy settings div to ensure markup matches */
-					<div className="PostsList--settings" />
-				) }
-				{ this.props.posts.data &&
-					this.props.posts.data.map( post => (
-						<PostComponent
-							key={ post.id }
-							data={ post }
-							expanded={ ! summaryEnabled || defaultPostView === 'expanded' }
-							onInvalidate={ () => this.props.invalidateData() }
-						/>
-					) )
-				}
-				<div className="pagination">
-					<Link to={ `/page/${ page ? Number( page ) + 1 : 2 }` }>Older</Link>
-					{ page && page > 1 ? (
-						<Link to={ `/page/${ page - 1 }` }>Newer</Link>
+			<PageTitle title={ getTitle() }>
+				<div className="PostsList">
+					{ this.props.posts.isLoading &&
+						<ContentLoader type="list" width={ 300 } />
+					}
+					{ summaryEnabled ? (
+						<div className="PostsList--settings">
+							<Button
+								disabled={ defaultPostView === 'summary' }
+								onClick={ () => this.props.setDefaultPostView( 'summary' ) }
+							>
+								Summary
+							</Button>
+							<Button
+								disabled={ defaultPostView === 'expanded' }
+								onClick={ () => this.props.setDefaultPostView( 'expanded' ) }
+							>
+								Expanded
+							</Button>
+						</div>
 					) : (
-						/* Hack to get pagination to float correctly */
-						/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
-						<a style={ { display: 'none' } }>&nbsp;</a>
+						/* Dummy settings div to ensure markup matches */
+						<div className="PostsList--settings" />
 					) }
+					{ this.props.posts.data &&
+						this.props.posts.data.map( post => (
+							<PostComponent
+								key={ post.id }
+								data={ post }
+								expanded={ ! summaryEnabled || defaultPostView === 'expanded' }
+								onInvalidate={ () => this.props.invalidateData() }
+							/>
+						) )
+					}
+					<div className="pagination">
+						<Link to={ `/page/${ page ? Number( page ) + 1 : 2 }` }>Older</Link>
+						{ page && page > 1 ? (
+							<Link to={ `/page/${ page - 1 }` }>Newer</Link>
+						) : (
+							/* Hack to get pagination to float correctly */
+							/* eslint-disable-next-line jsx-a11y/anchor-is-valid */
+							<a style={ { display: 'none' } }>&nbsp;</a>
+						) }
+					</div>
 				</div>
-			</div>
+			</PageTitle>
 		);
 	}
 }


### PR DESCRIPTION
This does not currently account for every case that `wp_title()` does, but is a start at least.

Fixes #26.