### PR TITLE
Fix Node.insertBefore render bug

### DIFF
--- a/src/components/Message/Content.js
+++ b/src/components/Message/Content.js
@@ -1,4 +1,5 @@
 import Interweave from 'interweave';
+import { memoize } from 'lodash/function';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -7,6 +8,8 @@ import Notification from '../Notification';
 import matchers from '../../matchers';
 
 import './Content.css';
+
+const preparseEmoji = window.wp && window.wp.emoji ? memoize( content => window.wp.emoji.parse( content ) ) : content => content;
 
 class ErrorBoundary extends React.Component {
 	constructor( props ) {
@@ -45,12 +48,17 @@ function Content( props ) {
 		);
 	}
 
+	// Parse emoji early to ensure it doesn't get replaced later by wp-emoji,
+	// which breaks React's rendering.
+	// https://github.com/humanmade/H2/issues/250
+	const html = preparseEmoji( props.html );
+
 	return (
 		<div className="PostContent">
 			<ErrorBoundary>
 				<Interweave
 					commonClass={ null }
-					content={ props.html }
+					content={ html }
 					matchers={ matchers }
 					tagName="fragment"
 				/>


### PR DESCRIPTION
The automatic emoji->Twemoji replacement is playing havoc with React's rendering using Interweave. Essentially, React renders out the DOM nodes, then attempts to update the DOM to insert the @-mentions once we load in the user data. However, in the meantime, wp-emoji has messed with our DOM and replaced the emoji with `<img />`, so React can't find the text node. (This doesn't occur with the legacy rendering because it's using `dangerouslySetInnerHTML`, so React isn't attempting to control the actual nodes.)

To solve this, we can pre-parse the HTML string to replace emoji before rendering it, ensuring that it's already handled by the time it gets to React. We need to conditionally do this, due to WP's use of Twemoji only as a fallback. For performance, I've memoized this using Lodash (which we're already using).

While I was here, I also added an error boundary to Message/Content to ensure we don't crash the whole page if a single post/comment can't render.

Fixes #250.