### PR TITLE
Use static filename for builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ node_js:
 script:
   - npm run lint
   - npm run build
+
+  # Move main JS file to a static name
+  - cp $(find ./build/static/js -name 'main.*.js') ./build/static/js/main.js
   - npm run check-size

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "bundlesize": [
     {
-      "path": "./build/static/js/main.*.js"
+      "path": "./build/static/js/main.js"
     }
   ]
 }


### PR DESCRIPTION
This should allow bundlesize to compare sizes across branches better. 🤞 