### PR TITLE
Add ability to paste URL over text

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -18,6 +18,9 @@ const apply = ( selection, start, end ) => {
 	return selection.length ? start + selection + end : start;
 };
 
+const URL_REGEX = /^https?:\/\/\S+$/i;
+const isAbsoluteUrl = text => URL_REGEX.test( text );
+
 const BUTTONS = {
 	bold: {
 		icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><rect x="0" fill="none" width="20" height="20"/><g><path d="M6 4v13h4.54c1.37 0 2.46-.33 3.26-1 .8-.66 1.2-1.58 1.2-2.77 0-.84-.17-1.51-.51-2.01s-.9-.85-1.67-1.03v-.09c.57-.1 1.02-.4 1.36-.9s.51-1.13.51-1.91c0-1.14-.39-1.98-1.17-2.5C12.75 4.26 11.5 4 9.78 4H6zm2.57 5.15V6.26h1.36c.73 0 1.27.11 1.61.32.34.22.51.58.51 1.07 0 .54-.16.92-.47 1.15s-.82.35-1.51.35h-1.5zm0 2.19h1.6c1.44 0 2.16.53 2.16 1.61 0 .6-.17 1.05-.51 1.34s-.86.43-1.57.43H8.57v-3.38z"/></g></svg>',
@@ -177,6 +180,13 @@ export default class Editor extends React.PureComponent {
 	onPaste = e => {
 		const html = e.clipboardData.getData( 'text/html' );
 		if ( ! html ) {
+			const text = e.clipboardData.getData( 'text/plain' );
+			if ( isAbsoluteUrl( text ) ) {
+				e.preventDefault();
+				this.onPasteLink( text );
+				return;
+			}
+
 			// Use default browser handling.
 			return;
 		}
@@ -189,6 +199,10 @@ export default class Editor extends React.PureComponent {
 
 		// Insert at the current selection point
 		this.onButton( null, () => markdown );
+	}
+
+	onPasteLink( url ) {
+		this.onButton( null, text => text ? `[${ text }](${ url })` : url );
 	}
 
 	onSubmit( e ) {


### PR DESCRIPTION
When pasting a URL while text is selected, this will link the selected text to the URL (using Markdown syntax) rather than replacing it.

(If a link is pasted without text selected, it will insert the URL text just like any other.)

h/t @willmot 