### PR TITLE
Fix height of sidebar when showing admin bar.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -73,7 +73,7 @@ body.admin-bar .App > .Outer > aside {
 @media screen and ( max-width: 782px ) {
 	body.admin-bar .App > .Outer > aside {
 		top: 48px;
-		height: calc( -48px + 100vh );
+		height: calc( 100vh - 48px );
 	}
 }
 


### PR DESCRIPTION
Irrelevant of showing the admin bar (and thus having some `top` push), the sidebar is always set to `100vh` height.

This PR adapts this so one can, for example, actually make use of the pagination in the Recent Posts widget (which is displayed as last one on Updates).