### PR TITLE
Restore relative sizing for headings

### DIFF
--- a/src/components/Message/Content.css
+++ b/src/components/Message/Content.css
@@ -96,8 +96,7 @@
 .PostContent h4,
 .PostContent h5,
 .PostContent h6 {
-	font-size: 1rem;
-	line-height: 1.555rem;
+	line-height: 1.555;
 	margin: 1rem 0;
 	text-transform: none;
 }


### PR DESCRIPTION
Fixes #310.

<img width="778" alt="screenshot 2018-12-07 14 56 05" src="https://user-images.githubusercontent.com/21655/49654653-59658600-fa30-11e8-8f7f-33be866f1306.png">
