### PR TITLE
Increase blur delay for hiding search suggestions

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -172,7 +172,7 @@ class SearchInput extends React.Component {
 	onBlur = () => {
 		window.setTimeout( () => {
 			this.setState( { showSuggest: false } );
-		}, 100 );
+		}, 200 );
 	}
 
 	onSelect = item => {


### PR DESCRIPTION
It appears that the blur event is firing before the click event does, causing the click to never register.

See #308, which this should solve, hopefully.