### PR TITLE
Support data-secret for WP embeds

### DIFF
--- a/src/components/Message/Content.js
+++ b/src/components/Message/Content.js
@@ -58,6 +58,9 @@ const transform = ( node, children ) => {
 				);
 			}
 
+			// For regular blockquotes, use built-in handling.
+			return;
+
 		default:
 			// Use built-in handling.
 			return;


### PR DESCRIPTION
WordPress embeds work by having markup like the following:

```html
<blockquote class="wp-embedded-content" data-secret="foo">
  Fallback content.
</blockquote>

<iframe class="wp-embedded-content" src="https://example.com/#?secret=foo" data-secret="foo"></iframe>
```

The `wp-embed` code hides the fallback blockquote once the source is loaded. However, Interweave blocks the custom `data-secret` attribute.

This PR passes `data-secret` through for blockquotes to allow this behaviour.