### PR TITLE
Preserve cursor on autocomplete

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -341,17 +341,23 @@ export default class Editor extends React.PureComponent {
 			trigger: completion.key,
 			onSelect: val => {
 				const content = this.state.content;
+				const before = content.substring( 0, completion.start );
 
 				const nextParts = [
-					content.substring( 0, completion.start ),
+					before,
 					val,
 					content.substring( completion.end ),
 				];
+				const nextCursor = before.length + val.length;
 
-				this.setState( {
-					completion: null,
-					content: nextParts.join( '' ),
-				} );
+				this.setState(
+					{
+						completion: null,
+						content: nextParts.join( '' ),
+						lastSelection: [ nextCursor, nextCursor ],
+					},
+					this.restoreSelection
+				);
 			},
 			onCancel: () => this.setState( { completion: null } ),
 		};


### PR DESCRIPTION
Uses the same mechanism as the toolbar/keyboard shortcuts to keep the cursor where you expect when autocompleting.

![h2-autocomplete-cursor](https://user-images.githubusercontent.com/21655/49811279-d8bdc700-fd5a-11e8-98e1-4458239799fc.gif)

See https://github.com/humanmade/H2/issues/327#issuecomment-445974107