### PR TITLE
Force create-react-app to use relative URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "h2",
   "version": "0.0.1",
   "private": true,
-  "homepage": "https://makeh2.hmn.md/content/themes/h2/build",
+  "homepage": ".",
   "devDependencies": {
     "@storybook/react": "^3.4.10",
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
In combination with #342, this should ensure assets are referred to correctly.

#342 fixed anything loaded via JS, but the `homepage` setting is still used at build time for places which can't use the dynamic path. In particular, CSS files can't use JS variables.

Using `.` as the homepage forces create-react-app to put the generators into relative path mode: https://github.com/facebook/create-react-app/blob/e59e0920f3bef0c2ac47bbf6b4ff3092c8ff08fb/packages/react-scripts/config/webpack.config.js#L67-L69

The combination of these two should fix #341 properly.