### PR TITLE
Update header stickiness to adapt to menu bar changes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,20 +60,22 @@
 	}
 }
 
-body.admin-bar .App > .Outer > aside {
-	top: 32px;
+@media screen and ( min-width: 600px ) and ( max-width: 782px ) {
+	body.admin-bar .App > .Outer > aside {
+		top: 46px;
+		height: calc( 100vh - 46px );
+	}
+}
+
+@media ( min-width: 783px ) {
+	body.admin-bar .App > .Outer > aside {
+		top: 32px;
+	}
 }
 
 @media ( min-width: 800px ) {
 	body.admin-bar .App > .Outer > aside {
 		height: calc( 100vh - 32px );
-	}
-}
-
-@media screen and ( max-width: 782px ) {
-	body.admin-bar .App > .Outer > aside {
-		top: 48px;
-		height: calc( 100vh - 48px );
 	}
 }
 

--- a/src/components/Comment.css
+++ b/src/components/Comment.css
@@ -35,13 +35,15 @@
 	z-index: 3;
 }
 
-body.admin-bar .Comment .Comment-Header {
-	top: 131px; /* 32 + 99 */
+@media screen and ( min-width: 600px ) and ( max-width: 782px ) {
+	body.admin-bar .Comment .Comment-Header {
+		top: 145px; /* 46 + 99 */
+	}
 }
 
-@media screen and ( max-width: 782px ) {
+@media screen and ( min-width: 783px ) {
 	body.admin-bar .Comment .Comment-Header {
-		top: 147px; /* 48 + 99 */
+		top: 131px; /* 32 + 99 */
 	}
 }
 

--- a/src/components/Post/index.css
+++ b/src/components/Post/index.css
@@ -29,13 +29,15 @@
 	height: 99px;
 }
 
-body.admin-bar .Post > header {
-	top: 32px;
+@media screen and ( min-width: 600px ) and ( max-width: 782px ) {
+	body.admin-bar .Post > header {
+		top: 46px;
+	}
 }
 
-@media screen and ( max-width: 782px ) {
+@media screen and ( min-width: 783px ) {
 	body.admin-bar .Post > header {
-		top: 48px;
+		top: 32px;
 	}
 }
 


### PR DESCRIPTION
This is a rage PR :smile: I consume H2 primarily on my phone and the experience drives me crazy. The reason: the values we used to choose the `top` and heights of sticky elements are outdated _vs_ what the WordPress admin bar looks like today, which results in a poor experience using H2 on phones or small screens. This updates to account for two major changes:

- WP admin bar is not sticky below 600px
- WP admin bar is 46px, not 48, on small screens

Before:

![image](https://user-images.githubusercontent.com/442115/59939454-05e3e400-9426-11e9-8d19-08f939245eb0.png)

(post text appears above header)

Now:
![image](https://user-images.githubusercontent.com/442115/59939504-2ad85700-9426-11e9-869a-2bc29e38cb1e.png)
