### PR TITLE
Load in as many comments as we can

### DIFF
--- a/src/components/Post/Comments.js
+++ b/src/components/Post/Comments.js
@@ -46,7 +46,10 @@ export default withArchive(
 	props => {
 		const { post } = props;
 
-		comments.registerArchive( post.id, { post: post.id } );
+		comments.registerArchive( post.id, {
+			post: post.id,
+			per_page: 100,
+		} );
 		return post.id;
 	},
 )( PostComments );


### PR DESCRIPTION
This was broken accidentally in #255. We can start using Repress' pagination to permanently fix this, but let's patch it quickly first.