### PR TITLE
Fix keyboard navigation for search results

### DIFF
--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -17,7 +17,7 @@ export class Results extends React.Component {
 
 	componentDidMount() {
 		this.keyHandler = e => {
-			const items = this.props.results && this.props.results.data;
+			const items = this.props.posts;
 			if ( ! this.props.visible || ! items || ! items.length ) {
 				return;
 			}


### PR DESCRIPTION
This was broken from when we switched to Repress, as the variable was never updated.

Fixes #370.