### PR TITLE
Correctly handle autocomplete for special emoji

### DIFF
--- a/src/components/Editor/EmojiCompletion.js
+++ b/src/components/Editor/EmojiCompletion.js
@@ -36,7 +36,7 @@ const EmojiCompletion = props => {
 			`:${ search }`,
 			{
 				custom: customEmoji,
-				maxResults: 1
+				maxResults: 1,
 			}
 		);
 


### PR DESCRIPTION
This ensures that autocomplete doesn't interrupt you when you're typing emoticons like :) or :D

Fixes #302. Requires #378.