### PR TITLE
Only resize iframe if significant height

### DIFF
--- a/src/components/Message/SafeEmbed.js
+++ b/src/components/Message/SafeEmbed.js
@@ -42,7 +42,13 @@ export default class SafeEmbed extends React.Component {
 				return;
 			}
 
-			node.style.height = doc.documentElement.offsetHeight + 'px';
+			const height = doc.documentElement.offsetHeight;
+			if ( height < 100 ) {
+				// Likely about:blank, skip until the document has loaded.
+				return;
+			}
+
+			node.style.height = height + 'px';
 		};
 
 		// Check that the node isn't cross-origin first.


### PR DESCRIPTION
Firefox loads about:blank first, which has a height of 8px, then loads the actual URL. For external URLs, this means that the iframe gets resized down and then never gets sized back up.

Fixes #386.