### PR TITLE
Link error message to New Issue page on GitHub

### DIFF
--- a/src/components/Message/Content.js
+++ b/src/components/Message/Content.js
@@ -29,7 +29,7 @@ class ErrorBoundary extends React.Component {
 		if ( this.state.error ) {
 			return (
 				<Notification type="error">
-					A problem occurred while rendering this content. Please report this as a bug.<br />
+					A problem occurred while rendering this content. Please <a href="https://github.com/humanmade/H2/issues/new" taget="_blank">report this as a bug</a>.<br />
 					<code>{ this.state.error.toString() }</code>
 				</Notification>
 			);


### PR DESCRIPTION
As noted by Nikhil, the notice to report any error as a bug should be linked to GitHub.

![screenshot](https://user-images.githubusercontent.com/6049306/66105890-ed569e80-e5bc-11e9-8efd-dd4219c0d2c4.png)

This PR simply turns part of the plain text into a proper call-to-action link.