### PR TITLE
Performance optimizations when loading single posts

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -61,10 +61,6 @@ function enqueue_assets() {
  */
 function get_script_data() {
 	$preload = [
-		'/wp/v2/posts',
-		'/h2/v1/site-switcher/sites',
-		'/h2/v1/widgets?sidebar=sidebar',
-		'/wp/v2/categories?per_page=100',
 		'/wp/v2/users/me',
 		'/wp/v2/users?per_page=100',
 	];
@@ -91,27 +87,6 @@ function get_script_data() {
 		],
 		'preload' => prefetch_urls( $preload ),
 	];
-
-	// Preload the comments and reactions for the posts too.
-	if ( isset( $data['preload']['/wp/v2/posts'] ) ) {
-		foreach ( $data['preload']['/wp/v2/posts'] as $post_data ) {
-			$id   = $post_data['id'];
-			$urls = [
-				sprintf( '/h2/v1/reactions?post=%d', $post_data['id'] ),
-				sprintf( '/wp/v2/comments?post=%d&per_page=100', $post_data['id'] ),
-				sprintf( '/wp/v2/users/%d', $post_data['author'] ),
-				sprintf( '/wp/v2/categories?include=%s', implode( ',', $post_data['categories'] ) ),
-			];
-
-			// Only fetch new URLs we don't already have.
-			$urls = array_filter( $urls, function ( $url ) use ( $data ) {
-				return empty( $data['preload'][ $url ] );
-			} );
-
-			$results         = prefetch_urls( $urls );
-			$data['preload'] = array_merge( $data['preload'], $results );
-		}
-	}
 
 	return $data;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -38,6 +38,8 @@ function set_up_theme() {
 		'before_widget' => '',
 		'after_widget'  => '',
 	] );
+
+	show_admin_bar( false );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -65,6 +65,9 @@ function get_script_data() {
 	$preload = [
 		'/wp/v2/users/me',
 		'/wp/v2/users?per_page=100',
+		'/h2/v1/site-switcher/sites',
+		'/h2/v1/widgets?sidebar=sidebar',
+		'/wp/v2/categories?per_page=100',
 	];
 
 	$data = [

--- a/src/components/SearchInput.js
+++ b/src/components/SearchInput.js
@@ -1,6 +1,6 @@
 import { withArchive } from '@humanmade/repress';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { FormattedRelative } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 
@@ -84,17 +84,11 @@ export class Results extends React.Component {
 
 	render() {
 		const { selected } = this.state;
-		const { loading, posts, term, visible } = this.props;
+		const { loading, posts, term } = this.props;
 
-		const classes = [
-			'SearchInput__results',
-			visible && 'SearchInput__results--visible',
-		];
 		return (
-			<div className={ classes.filter( Boolean ).join( ' ' ) }>
-				{ term === '' ? (
-					<p>Start typing to search.</p>
-				) : loading ? (
+			<Fragment>
+				{ loading ? (
 					<p>Loading results for “{ term }”</p>
 				) : ( posts && posts.length > 0 ) ? (
 					<ul>
@@ -131,7 +125,7 @@ export class Results extends React.Component {
 				) : (
 					<p>No results found.</p>
 				) }
-			</div>
+			</Fragment>
 		);
 	}
 }
@@ -191,6 +185,11 @@ class SearchInput extends React.Component {
 		const term = this.state.value === null ? ( termFromURL && termFromURL[1] ) || '' : this.state.value;
 		const Results = this.props.resultsComponent;
 
+		const classes = [
+			'SearchInput__results',
+			this.state.showSuggest && 'SearchInput__results--visible',
+		];
+
 		return (
 			<form
 				className="SearchInput"
@@ -208,12 +207,17 @@ class SearchInput extends React.Component {
 					/>
 				</div>
 
-				<Results
-					term={ term }
-					visible={ this.state.showSuggest }
-					onSelect={ this.onSelect }
-					onShowResults={ this.onSubmit }
-				/>
+				<div className={ classes.filter( Boolean ).join( ' ' ) }>
+					{ term === '' ? (
+						<p>Start typing to search.</p>
+					) : (
+						<Results
+							term={ term }
+							onSelect={ this.onSelect }
+							onShowResults={ this.onSubmit }
+						/>
+					) }
+				</div>
 			</form>
 		);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,18 @@ import loadPlugins from './plugins/load';
 
 import './hm-pattern-library/assets/styles/juniper.css';
 
-const currentUser = window.H2Data.preload['/wp/v2/users/me'] ? window.H2Data.preload['/wp/v2/users/me'].id : null;
+const currentUser = window.H2Data.legacyPreload['/wp/v2/users/me'] ? window.H2Data.legacyPreload['/wp/v2/users/me'].id : null;
 const initialState = {
 	users: {
 		archives: {
-			all: window.H2Data.preload['/wp/v2/users?per_page=100'].map( user => user.id ),
+			all: window.H2Data.legacyPreload['/wp/v2/users?per_page=100'].map( user => user.id ),
 			me: currentUser ? [ currentUser ] : [],
 		},
 		current: currentUser,
-		posts: window.H2Data.preload['/wp/v2/users?per_page=100'],
+		posts: window.H2Data.legacyPreload['/wp/v2/users?per_page=100'],
+	},
+	posts: {
+		posts: window.H2Data.preload.posts,
 	},
 };
 
@@ -56,7 +59,7 @@ const render = Main => {
 				<IntlProvider locale="en">
 					<RestApiProvider
 						fetch={ ( url, ...args ) => api.fetch( url, ...args ) }
-						initialData={ window.H2Data.preload }
+						initialData={ window.H2Data.legacyPreload }
 					>
 						<Router>
 							<Main />


### PR DESCRIPTION
Depends on https://github.com/humanmade/repress/issues/34

Make use of the new Repress optimizers to re-use existing loaded data for single pages. This works when loading a single page fresh (via embedded in page preloaded data), and instant page loads when clicking a post from an archive page.