### PR TITLE
Return undefined, not null, for regular lists

### DIFF
--- a/src/embeds/tasklist.js
+++ b/src/embeds/tasklist.js
@@ -27,7 +27,7 @@ export const parseListItem = ( node, children ) => {
 
 export const parseList = ( node, children ) => {
 	if ( node.className !== 'Tasklist' ) {
-		return null;
+		return;
 	}
 
 	// Parse out our tasks.


### PR DESCRIPTION
null indicates the element should be skipped entirely, but we actually want to use the default rendering.

I missed this during testing, as mixed lists (regular items in the list alongside task items) work just fine, and I didn't test thoroughly enough with the older content.

See #409.