### PR TITLE
Ensure posts are cleared after the content

### DIFF
--- a/src/components/Post/index.css
+++ b/src/components/Post/index.css
@@ -23,6 +23,7 @@
 }
 
 .Post-footer-actions {
+	clear: both;
 	display: flex;
 	margin: 1.666rem 0 1.248rem;
 	justify-content: space-between;


### PR DESCRIPTION
Floating images can currently overflow outside of the content area, so let's make sure that doesn't happen.