### PR TITLE
Decode category names

### DIFF
--- a/src/components/Message/Header.js
+++ b/src/components/Message/Header.js
@@ -77,7 +77,9 @@ export class MessageHeader extends React.Component {
 						<ul className="Message-Header__categories">
 							{ categories.map( category => (
 								<li key={ category.id }>
-									<Link href={ category.link }>{ category.name }</Link>
+									<Link href={ category.link }>
+										{ decodeEntities( category.name ) }
+									</Link>
 								</li>
 							) ) }
 						</ul>


### PR DESCRIPTION
Fixes #419 by decoding HTML entities in category names, just like it is done for other content such as the post title.