### PR TITLE
Introduce ImageLink component to open image links in a Modal

### DIFF
--- a/src/components/ImageLink.css
+++ b/src/components/ImageLink.css
@@ -1,0 +1,11 @@
+.Modal--Image .Modal-inner {
+   max-width: 90vw;
+   max-height: 90vh;
+   width: auto;
+   height: auto;
+}
+
+.Modal--Image img {
+   height: auto !important;
+   width: auto !important;
+}

--- a/src/components/ImageLink.js
+++ b/src/components/ImageLink.js
@@ -1,0 +1,31 @@
+import React, { useState, Fragment } from 'react';
+import Modal from './Modal';
+
+import './ImageLink.css';
+
+export default function ImageLink( props ) {
+	const { href, className, children } = props;
+	const [ isModalOpen, setModalOpenState ] = useState( false );
+
+	return (
+		<Fragment>
+			<a
+				{ ...props }
+				href={ href }
+				className={ `ImageLink ${ className || '' }` }
+				onClick={ e => {
+					setModalOpenState( true );
+					e.preventDefault();
+					return false;
+				} }
+			>
+				{ children }
+			</a>
+			{ isModalOpen && (
+				<Modal onDismiss={ () => setModalOpenState( false ) } className='Modal--Image'>
+					{ children }
+				</Modal>
+			)}
+		</Fragment>
+	);
+}

--- a/src/components/ImageLink.stories.js
+++ b/src/components/ImageLink.stories.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ImageLink  from './ImageLink';
+
+export default {
+	title: 'Components|ImageLink',
+}
+
+export const Basic = () => (
+	<ImageLink
+	    href={ '//placehold.it/500x500' }
+	    className='imagelink-anchor'
+	    style={ {
+			display: 'block',
+			maxWidth: '200px',
+		} }
+	>
+		<img
+		    alt=''
+		    src='//placehold.it/700x700'
+		/>
+	</ImageLink>
+);

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -3,6 +3,7 @@ import { Link as InternalLink, matchPath } from 'react-router-dom';
 
 import PostHovercard from './PostHovercard';
 import { POST_ROUTE } from '../App';
+import ImageLink from './ImageLink';
 
 export default function Link( { children, disablePreviews, href, ...props } ) {
 	const root = window.H2Data.site.home;
@@ -15,6 +16,14 @@ export default function Link( { children, disablePreviews, href, ...props } ) {
 			>
 				{ children }
 			</a>
+		);
+	}
+
+	if ( href.match( /\.(png|jpg|jpeg)$/ ) ) {
+		return (
+			<ImageLink { ...props } href={ href }>
+				{ children }
+			</ImageLink>
 		);
 	}
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -6,10 +6,10 @@ import TitleBar from './Sidebar/TitleBar';
 import './Modal.css';
 
 export default function Modal( props ) {
-	const { children, title, onDismiss } = props;
+	const { children, title, className, onDismiss } = props;
 
 	return (
-		<div className="Modal">
+		<div className={ `Modal ${ className }` }>
 			<Overlay
 				onClick={ onDismiss }
 			/>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import Overlay from './Overlay';
 import TitleBar from './Sidebar/TitleBar';
@@ -7,6 +7,14 @@ import './Modal.css';
 
 export default function Modal( props ) {
 	const { children, title, className, onDismiss } = props;
+	const onKeyUp = e => e.key === 'Escape' && onDismiss();
+
+	// Allow using ESCAPE button to dismiss the modal
+	useEffect( () => {
+		document.addEventListener( 'keyup', onKeyUp );
+
+		return () => document.removeEventListener( 'keyup', onKeyUp );
+	}, [] );
 
 	return (
 		<div className={ `Modal ${ className }` }>


### PR DESCRIPTION
Fixes #422 

- This opens image links in modals instead of the currently broken functionality in galleries ( check linked issue for reproduction steps ).
- This also adds handling to use Escape button to dismiss modals.