### PR TITLE
Correct anchor links back to relative

### DIFF
--- a/src/components/Message/Content.js
+++ b/src/components/Message/Content.js
@@ -70,7 +70,7 @@ const transform = ( node, children ) => {
 		case 'UL':
 			return parseList( node, children );
 
-		case 'A':
+		case 'A': {
 			let href = node.href;
 
 			if ( href.startsWith( 'about:blank#' ) ) {
@@ -87,6 +87,7 @@ const transform = ( node, children ) => {
 					{ children }
 				</Link>
 			);
+		}
 
 		default:
 			// Use built-in handling.


### PR DESCRIPTION
Due to the way that HTML content is parsed, the base URL is set to about:blank, and all URLs are absolutised. This makes sense 99% of the time for security, but in-page URLs break with this approach.

See https://github.com/humanmade/H2/issues/418#issuecomment-665428778