### PR TITLE
Prevent SVG loading indicators from expanding page width

### DIFF
--- a/src/components/Comment/Loader.css
+++ b/src/components/Comment/Loader.css
@@ -1,3 +1,9 @@
 .Comment-Loader--mobile {
 	margin-left: -20px;
 }
+
+/* Prevent fixed-aspect loader SVGs from breaking page width */
+.Loader-Wrapper {
+	max-width: 100vw;
+	overflow: hidden;
+}

--- a/src/components/Comment/Loader.js
+++ b/src/components/Comment/Loader.js
@@ -29,27 +29,29 @@ export default class CommentLoader extends React.Component {
 		if ( this.state.isMobile ) {
 			contentOffset = 42;
 			return (
-				<ContentLoader
-					className="Comment-Loader Comment-Loader--mobile"
-					height={ contentOffset + 5 * textLineHeight }
-					width={ width }
-					style={ { width } }
-				>
-					{ /* Avatar */ }
-					<circle cx="21" cy="12" r="12" />
+				<div class="Loader-Wrapper">
+					<ContentLoader
+						className="Comment-Loader Comment-Loader--mobile"
+						height={ contentOffset + 5 * textLineHeight }
+						width={ width }
+						style={ { width } }
+					>
+						{ /* Avatar */ }
+						<circle cx="21" cy="12" r="12" />
 
-					{ /* Timeline */ }
-					<rect x="20" width="3" height={ contentOffset + 5 * textLineHeight } />
+						{ /* Timeline */ }
+						<rect x="20" width="3" height={ contentOffset + 5 * textLineHeight } />
 
-					{ /* Title */ }
-					<rect x="40" y="4" rx="4" ry="4" width="240" height="16" />
+						{ /* Title */ }
+						<rect x="40" y="4" rx="4" ry="4" width="240" height="16" />
 
-					{ /* Text */ }
-					<rect x="40" y={ contentOffset } rx="3" ry="3" width="325" height="13" />
-					<rect x="40" y={ contentOffset + textLineHeight } rx="3" ry="3" width="313" height="13" />
-					<rect x="40" y={ contentOffset + 2 * textLineHeight } rx="3" ry="3" width="280" height="13" />
-					<rect x="40" y={ contentOffset + 3 * textLineHeight } rx="3" ry="3" width="310" height="13" />
-				</ContentLoader>
+						{ /* Text */ }
+						<rect x="40" y={ contentOffset } rx="3" ry="3" width="325" height="13" />
+						<rect x="40" y={ contentOffset + textLineHeight } rx="3" ry="3" width="313" height="13" />
+						<rect x="40" y={ contentOffset + 2 * textLineHeight } rx="3" ry="3" width="280" height="13" />
+						<rect x="40" y={ contentOffset + 3 * textLineHeight } rx="3" ry="3" width="310" height="13" />
+					</ContentLoader>
+				</div>
 			);
 		}
 


### PR DESCRIPTION
Fixes #387

I tracked this down by pausing JS script execution while the page was loading in a narrow viewport, which let me see that the loading elements were displaying at a wide fixed width that exceeded the dimensions of the viewport. Wrapping mobile loaders in a div that cannot exceed the page dimensions appears to fix the issue in my browser; the width can be adjusted if, after deploy, it still doesn't look right on mobile.