### PR TITLE
Correct sticky header anchoring at 600px

### DIFF
--- a/src/components/Message/Header.css
+++ b/src/components/Message/Header.css
@@ -18,7 +18,7 @@
 	z-index: 5;
 }
 
-@media screen and ( min-width: 600px ) and ( max-width: 782px ) {
+@media screen and ( min-width: 601px ) and ( max-width: 782px ) {
 	body.admin-bar .Message-Header--sticky {
 		top: 46px;
 	}


### PR DESCRIPTION
After #445 there is a one-pixel range where the header does not "sick" properly to the top at 600px, because we are using both `min-width` _and_ `max-width` styles at that breakpoint. Adjusting this value upwards by 1px fixes the issue with fewer changes than trying to alter a corresponding `max-width` value.

Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/442115/167668115-f400df67-c4fd-4a09-a2ca-14115f3231bd.png">
(note that text appears above sticky header)

After
<img width="603" alt="image" src="https://user-images.githubusercontent.com/442115/167667864-c4918b17-faac-4d9d-8d17-cf14ab140caf.png">
