### PR TITLE
Scroll to top on navigate

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,13 @@ class App extends Component {
 		window.location.href = '/wp-login.php?action=logout';
 	}
 
+	componentDidUpdate( prevProps ) {
+		// Scroll back to top when navigating to a new page.
+		if ( prevProps.location && this.props.location && prevProps.location !== this.props.location ) {
+			window.scrollTo( { top: 0 } );
+		}
+	}
+
 	componentDidMount() {
 		this.unsubscribeFromHistory = this.props.history.listen( this.handleLocationChange );
 	}


### PR DESCRIPTION
Addresses a longstanding usability issue by adding a change listener to the base App component which will trigger a window-level scroll-to-top when the Router location changes. When testing locally this has correctly fired only when navigating to a new page or clicking through to a post from the list, as you would expect from a traditionally-rendered site.

Fixes #194