### PR TITLE
Fix bug where page content cannot be edited on frontend

### DIFF
--- a/src/components/Page/Container.js
+++ b/src/components/Page/Container.js
@@ -1,13 +1,23 @@
-import { withArchive } from '@humanmade/repress';
+import { withArchive, withSingle } from '@humanmade/repress';
 import React, { Component } from 'react';
+import { compose } from 'redux';
 
-import { withUsers } from '../../hocs';
+import { withUser } from '../../hocs';
 import { pages } from '../../types';
 import { decodeEntities } from '../../util';
 import PageTitle from '../PageTitle';
 import Loader from '../Post/Loader';
 
 import Page from './index';
+
+const ConnectedPage = compose(
+	withSingle(
+		pages,
+		state => state.pages,
+		props => props.post.id
+	),
+	withUser( props => props.post.author )
+)( Page );
 
 class Container extends Component {
 	state = {
@@ -56,7 +66,7 @@ class Container extends Component {
 			<PageTitle title={ title }>
 				<div className="PostsList">
 					<div className="PostsList--settings" />
-					<Page
+					<ConnectedPage
 						post={ page }
 					/>
 				</div>
@@ -65,10 +75,8 @@ class Container extends Component {
 	}
 }
 
-const ConnectedPostsList = withArchive(
+export default withArchive(
 	pages,
 	state => state.pages,
 	props => pages.idForPath( props.match.params.pageName )
 )( Container );
-
-export default withUsers( ConnectedPostsList );

--- a/src/components/Page/index.js
+++ b/src/components/Page/index.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Slot } from 'react-slot-fill';
 
-import { withUser } from '../../hocs';
 import {
 	Post as PostShape,
 } from '../../shapes';
@@ -116,4 +115,4 @@ Page.propTypes = {
 	data: PostShape.isRequired,
 };
 
-export default withUser( props => props.post.author )( Page );
+export default Page;


### PR DESCRIPTION
The Page component didn't get the `withSingle` treatment and has an overall different file structure to Posts, so the request to load the edit-context data failed because no `onLoad` method was present on the component. This PR adds the withSingle HOC to the Page so that it matches the behavior of the Post, without altering the overall file structure too much.

I could not find any application of the `withUsers` HOC, so I removed that too for cleanliness.

Fixes #433