### PR TITLE
Fix broken frontend markdown preview (#503)

### DIFF
--- a/src/components/RemotePreview.js
+++ b/src/components/RemotePreview.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import compileMarkdown from '../compile-markdown';
-import { posts } from '../types';
 
 import MessageContent from './Message/Content';
 import Notification from './Notification';
@@ -33,14 +32,15 @@ export default class RemotePreview extends React.Component {
 			type: this.props.type,
 		};
 
-		posts.fetch( `${ window.wpApiSettings.root }h2/v1/preview`, {}, {
+		fetch( `${ window.wpApiSettings.root }h2/v1/preview`, {
+			method: 'POST',
+			credentials: 'same-origin',
 			headers: {
-				Accept: 'application/json',
-				'Content-Type': 'application/json',
+			  'Content-Type': 'application/json',
 			},
 			body: JSON.stringify( body ),
-			method: 'POST',
 		} )
+			.then( response => response.json() )
 			.then( response => {
 				this.setState( {
 					compiledPreview: response.html,


### PR DESCRIPTION
After introducing a `_fields` limiter on the posts endpoint, it unintentionally broke preview on the frontend because that request was using the posts handler for some reason. Since it is a `fetch` against a totally different endpoint than the posts endpoint, there is no reason for it to use the posts handler—and by switching that out, it removes the unintended `_fields` constraint.

Fixes #503