### PR TITLE
Revert change which flipped comment order

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -14,10 +14,6 @@ export const comments = new handler( {
 	type: 'comments',
 	url: `${ window.wpApiSettings.root }wp/v2/comments`,
 	nonce: window.wpApiSettings.nonce,
-	query: {
-		_fields: 'id,link,date_gmt,content,post,author,parent,author_name,user_can',
-		order: 'asc',
-	},
 } );
 
 export const reactions = new handler( {


### PR DESCRIPTION
Attempting to be clever about what fields we request had unintended consequences for comment ordering, and also introduced an artificial cutoff for comment count returned.

Fixes #505 