### PR TITLE
459: warn before losing comments

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedRelative } from 'react-intl';
 import { connect } from 'react-redux';
+import { Prompt } from 'react-router-dom';
 import getCaretCoordinates from 'textarea-caret';
 import Turndown from 'turndown';
 
@@ -481,6 +482,10 @@ class Editor extends React.PureComponent {
 							/>
 						) }
 					</DropUpload>
+					<Prompt
+						when={ ! ( this.state.content === '' || ( this.props.initialValue && this.state.content === this.props.initialValue ) ) }
+						message='You have unsaved content. Are you sure you want to leave?'
+					/>
 
 					{ mode !== 'preview' ? this.getCompletion() : null }
 				</div>

--- a/src/components/Message/WriteComment.css
+++ b/src/components/Message/WriteComment.css
@@ -18,6 +18,9 @@
 	margin-top: -1.36667rem;
 }
 
+.WriteComment .Editor-editor {
+	min-height: 12rem;
+}
 
 @media ( max-width: 600px ) {
 	.WriteComment > header {


### PR DESCRIPTION
This is a partial solution for #459. It does not persist comment data, but it does use the React Router `<Prompt>` component to show the user a warning before they take a navigation action which would cause them to lose draft content.