### PR TITLE
459: Enhance wording of lost-work warning on navigation

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -59,6 +59,8 @@ const BUTTONS = {
 	},
 };
 
+const navigateWarning = 'You have unsaved content. Are you sure you want to leave? Your content will not be saved.';
+
 const completions = {
 	'@': MentionCompletion,
 	':': EmojiCompletion,
@@ -99,9 +101,8 @@ class Editor extends React.PureComponent {
 			return;
 		}
 
-		const warning = 'You have unsaved content. Are you sure you want to leave?';
-		e.returnValue = warning;
-		return warning;
+		e.returnValue = navigateWarning;
+		return navigateWarning;
 	}
 
 	componentDidUpdate() {
@@ -484,7 +485,7 @@ class Editor extends React.PureComponent {
 					</DropUpload>
 					<Prompt
 						when={ ! ( this.state.content === '' || ( this.props.initialValue && this.state.content === this.props.initialValue ) ) }
-						message='You have unsaved content. Are you sure you want to leave?'
+						message={ navigateWarning }
 					/>
 
 					{ mode !== 'preview' ? this.getCompletion() : null }


### PR DESCRIPTION
@missjwo Per your latest comment on #459,

> If we change the warning to include "your content will not be saved" as part of the message, I think we could close this off

does this sound good?
<img width="429" alt="image" src="https://user-images.githubusercontent.com/442115/169530018-f8a9c2d0-8e0a-43b5-bd4f-51d83166611f.png">

Fixes #459 