### PR TITLE
Instruct build pipeline to use Node v12 for H2

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -2,5 +2,6 @@
 
 set -e
 
+nvm use v12
 npm install
 npm run build


### PR DESCRIPTION
Because of the build order of plugins in the main site network, the H2 theme is being built using Node 8 -- which fails. This PR should instruct the CI runner to switch to node 12 (compatible) before building.