### PR TITLE
Fix issue with nvm access and restore prior version after build

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -11,7 +11,7 @@ if [ -d "$HOME/.nvm" ]; then
 	nvm use v12
 fi
 
-npm install
+npm ci
 npm run build
 
 # clean-up


### PR DESCRIPTION
@missjwo I spoke too soon, there _is_ a better way to do it. This is from our playbook theme, where we for one, make sure NVM is accessible before running it! since this runs in a different process than the parent build shell. It also stores the old version of node and restores it after the build completes, in addition to removing node modules to reduce the storage size of the cached image.