### PR TITLE
329: Improve hovercard display on small screens

### DIFF
--- a/src/components/Hovercard.css
+++ b/src/components/Hovercard.css
@@ -56,3 +56,9 @@
 	border: 10px solid transparent;
 	border-bottom-color: var( --hm-red );
 }
+
+@media ( max-width: 475px ) {
+	.Hovercard-Card {
+		max-width: calc( 100vw - 52px );
+	}
+}

--- a/src/components/Hovercard.js
+++ b/src/components/Hovercard.js
@@ -42,6 +42,11 @@ function getPosition( target, width ) {
 	const diff = originalLeft - style.left;
 	style.pointerOffset = diff;
 
+	// Move pointer back onscreen if small window breakpoint has constrained width.
+	if ( document.documentElement.clientWidth < width + style.left * 2 ) {
+		style.pointerOffset += ( width - document.documentElement.clientWidth ) / 2 + style.left;
+	}
+
 	return style;
 }
 

--- a/src/components/UserHovercard.css
+++ b/src/components/UserHovercard.css
@@ -67,3 +67,14 @@
 	margin: 0;
 	font-size: 0.9em;
 }
+
+@media ( max-width: 475px ) {
+	.UserHovercard {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.UserHovercard .Map {
+		margin: 1em auto 0;
+	}
+}


### PR DESCRIPTION
Use CSS to constrain the width and switch to a vertical stack of map underneath author info. Adjust the arrow positioning JS to move it back into place on small screens. Fixes #329 

<img width="247" alt="image" src="https://user-images.githubusercontent.com/442115/169570501-838a5968-3cdd-48b5-9726-19cf709981ab.png">


<details>
<summary>Gif showing responsiveness</summary>

![user hovercard width](https://user-images.githubusercontent.com/442115/169570546-d2ba711d-f05b-407d-a2ec-a4fca7a82887.gif)

</details>
