### PR TITLE
Do not cache /me

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -154,7 +154,7 @@ function get_preload_urls() : array {
 		// '/h2/v1/site-switcher/sites',
 		'/h2/v1/widgets?sidebar=sidebar',
 		// '/wp/v2/categories?per_page=100',
-		'/wp/v2/users/me?_fields=id,name,facts,link,slug,avatar_urls,meta',
+		// '/wp/v2/users/me?_fields=id,name,facts,link,slug,avatar_urls,meta',
 		'/wp/v2/users?per_page=200&_fields=id,name,facts,link,slug,avatar_urls,meta',
 	];
 }


### PR DESCRIPTION
By caching the preloaded data, whoever signs on to H2 first will be the current user for everybody for the rest of the hour. This definitely isn't what we want!

Should fix #539.