### PR TITLE
Use relative dates for 1 week after publish

### DIFF
--- a/src/components/FormattedDate.js
+++ b/src/components/FormattedDate.js
@@ -9,7 +9,7 @@ export default function FormattedDate( props ) {
 
 	return (
 		<time dateTime={ date } title={ date }>
-			{ hoursSinceComment < 24 ? (
+			{ hoursSinceComment < ( 24 * 7 ) ? (
 				<FormattedRelative value={ date } />
 			) : (
 				// Canada helpfully uses YYYY-MM-DD. We do not use the ISO


### PR DESCRIPTION
As requested by @daisymc and @jennybeaumont , leave dates in relative display until they are older than 1 week. This balances the request in #507 with the preference for relative dates when we are looking at posts in the recent past.