### PR TITLE
Print stylesheet: Handle reaction buttons and page width edge cases

### DIFF
--- a/src/_print.scss
+++ b/src/_print.scss
@@ -9,8 +9,15 @@
 	.Post-Summary-actions button,
 	.Post-Summary-people,
 	.Comment-Actions,
-	.Message-Header__Collapse-Button {
+	.ButtonGroup,
+	.Message-Header__Collapse-Button,
+	.reactions__add-reaction {
 		display: none;
+	}
+
+	.Inner {
+		width: unset;
+		max-width: unset;
 	}
 
 	.Message-Header--constrained {

--- a/src/plugins/reactions/Reactions.js
+++ b/src/plugins/reactions/Reactions.js
@@ -143,7 +143,7 @@ export class Reactions extends Component {
 					);
 				} ) }
 				<button
-					className={ 'btn btn--small btn--tertiary' + ( loading ? ' loading' : '' ) }
+					className={ 'reactions__add-reaction btn btn--small btn--tertiary' + ( loading ? ' loading' : '' ) }
 					onClick={ value => this.setState( { isOpen: ! this.state.isOpen  } ) }
 					key="button"
 					disabled={ loading }


### PR DESCRIPTION
Removes the blank box on the right:
<img width="131" alt="image" src="https://user-images.githubusercontent.com/442115/171725786-1b26efdf-9f96-4c62-8671-e0166386fe73.png">

and ensures the page goes full-width in some browsers