### PR TITLE
Make all links blue like playbook

### DIFF
--- a/src/components/LinkButton.css
+++ b/src/components/LinkButton.css
@@ -8,13 +8,13 @@
 	padding: 0;
 	margin: 0;
 	overflow: visible;
-	color: var( --hm-red );
+	color: var( --hm-vibrant-blue );
 	transition: color .2s ease-in, background .2s ease-in;
 }
 
 .LinkButton:hover,
 .LinkButton:focus {
-	color: var( --hm-red );
+	color: var( --hm-vibrant-blue );
 	transition: color .2s ease-out, background .2s ease-out;
 	text-decoration: underline;
 	outline: none;

--- a/src/editor-style.scss
+++ b/src/editor-style.scss
@@ -18,7 +18,7 @@ a {
     &:hover:not(:disabled):not([aria-disabled="true"]) {
         border-bottom: none;
         text-decoration: underline;
-        color: var(--hm-red);
+        color: var(--hm-vibrant-blue);
     }
 }
 

--- a/src/pattern-library/assets/sass/_variables.scss
+++ b/src/pattern-library/assets/sass/_variables.scss
@@ -45,9 +45,9 @@ $color-text-dark:    $hm-dark-grey !default;
 $color-text-heading: $hm-dark-grey !default;
 $color-text-pre:     $hm-warm-grey !default;
 
-$color-link:         $hm-red !default;
-$color-link-hover:   $hm-red !default;
-$color-link-visited: darken( $hm-red, 3% ) !default;
+$color-link:         $hm-vibrant-blue !default;
+$color-link-hover:   $hm-vibrant-blue !default;
+$color-link-visited: darken( $hm-vibrant-blue, 3% ) !default;
 
 $color-background-pre: $hm-light-grey !default;
 


### PR DESCRIPTION
The new red is not suitable for body text due to how light it is, so the legibility of the site suffered after #560. This PR alters the text links to be blue, mirroring the style used in the HM Playbook and the new public-facing HM site.

Before | After
---- | ----
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/442115/209251922-5aad3281-beeb-4b4d-8228-53d65d7366b8.png"> | <img width="1174" alt="image" src="https://user-images.githubusercontent.com/442115/209251879-03aa9793-01df-4002-a031-03d3578e5eb1.png">


This is available to test at https://updates.hmn-dev.altis.cloud