### PR TITLE
Switch to system default font stack for legibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 .App {
-	font-family: 'Proxima-Nova', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-weight: 400;
 	flex-direction: column;
 	flex: 1;
 	transition: transform 300ms;

--- a/src/components/Editor/index.css
+++ b/src/components/Editor/index.css
@@ -91,7 +91,7 @@
 
 .Editor-tabs,
 .Editor-toolbar {
-	font-family: "proxima-nova", sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-weight: 700;
 	text-transform: uppercase;
 	letter-spacing: 0.01em;

--- a/src/editor-style.scss
+++ b/src/editor-style.scss
@@ -32,7 +32,7 @@ a em {
     max-width: 650px;
     margin: auto;
     line-height: 1.5555;
-	font-family: 'Proxima-Nova', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 
@@ -41,7 +41,7 @@ a em {
     max-width: 650px;
     margin: 0 auto 1.5rem;
     padding-right: 120px;
-	font-family: 'Proxima-Nova', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     font-size: 2rem;
 }
 


### PR DESCRIPTION
Font legibility has repeatedly been brought up as an issue starting with #453, and while we have gotten inconsistent reports of whether it has changed (it looks the same to several people polled, while others felt it did change, possibly as a result of the rebranding or the v12 Altis upgrade—the listed font "Proxima Nova" and the listed font weight that show in dev tools have not changed), @CoreyBenefiel has specified that the bolder text on the HMN-DEV network is preferable. That version is darker because it is using a different font—specifically, Helvetica, instead of the old Proxima Nova which was used (via Typekit) on the old version of the HM pattern library.

This PR swaps the theme to use a system-default font stack, borrowing the one from WordPress core itself. That will include Helvetica on some machines, but it will always pick the font that the OS renders best, so it won't fall back to a base `sans-serif` on e.g. Linux systems or versions of Windows which don't come bundled with Helvetica.

Visual comparison: Current production (proxima nova) is left, Dev (system default stack) is right
<img width="1369" alt="image" src="https://user-images.githubusercontent.com/442115/209252080-282aab81-fa18-435b-848d-971159d1de1f.png">

This is available to test at https://updates.hmn-dev.altis.cloud