### PR TITLE
Disable Bundlesize step in Travis, it is failing with a 401 currently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ script:
   - npm run build
 
   # Move main JS file to a static name
-  - npm run check-size
+  # - npm run check-size
+  # Disabled 2022-12-23 because Travis started getting a 401 trying to post back
+  # the bundle size stats.


### PR DESCRIPTION
We can re-enable this in the new year depending on what we determine the priority of those bundlesize stats are versus other initiatives