### PR TITLE
Match hyphens in @mentions

### DIFF
--- a/src/matchers.js
+++ b/src/matchers.js
@@ -20,7 +20,7 @@ export class MentionMatcher extends Matcher {
 	}
 
 	match( string ) {
-		return this.doMatch( string, /@(\w+)/, matches => ( { username: matches[1] } ) );
+		return this.doMatch( string, /@([\w-]+)/, matches => ( { username: matches[1] } ) );
 	}
 }
 


### PR DESCRIPTION
## Problem

@mentions of users whose slug contains a hyphen (e.g. `@dominic-huxley`) render as plain text instead of a link, while single-token names (e.g. `@tomnowell`) link correctly. This is a parsing bug, not a missing-account issue — the affected users have valid author archives.

## Cause

`src/matchers.js` matched mentions with `/@(\w+)/`. `\w` is `[A-Za-z0-9_]` and excludes `-`, so `@dominic-huxley` only captured `dominic`. `Mention.js` then looked up the slug `dominic`, found no user, and `AuthorLink` returns its children verbatim (no link) when there is no user.

## Fix

Allow hyphens in the captured username: `/@([\w-]+)/`. WordPress user nicenames are limited to lowercase letters, digits, and hyphens, so this covers every valid slug. Verified locally: hyphenated mentions now link.

Targets `main` so the release Action rebuilds the bundle on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)