### PR TITLE
Pass ordered-list start through custom renderer

### DIFF
--- a/src/compile-markdown.js
+++ b/src/compile-markdown.js
@@ -12,12 +12,12 @@ class CustomRender extends marked.Renderer {
 		return super.link( href, title, text );
 	}
 
-	list( body, ordered ) {
+	list( body, ordered, start ) {
 		if ( body.indexOf( TASK_LIST_TOKEN ) >= 0 ) {
 			return '<ul class="Tasklist">' + body.replace( new RegExp( TASK_LIST_TOKEN, 'g' ), '' ) + '</ul>';
 		}
 
-		return super.list( body, ordered );
+		return super.list( body, ordered, start );
 	}
 
 	listitem( text ) {


### PR DESCRIPTION
## Content impact

Affects **numbered (ordered) lists** in posts.

- Visible numbering was never broken — lists still showed 1, 2, 3. But after the marked 0.3.19 → 4.x upgrade, every ordered list emitted invalid `<ol start="undefined">` in the HTML (browsers ignore it).
- A list written to start at a number other than 1 (e.g. `7.` `8.` `9.`) had its start dropped and renumbered from 1.

## Cause

marked 4's `Renderer.list` signature is `list(body, ordered, start)`. The custom override in `src/compile-markdown.js` was written for the old (marked 0.3) `list(body, ordered)` signature and called `super.list(body, ordered)`, so `start` was always `undefined`.

## Fix

Accept and forward `start`. Ordered lists starting at 1 now render a clean `<ol>`; a list starting at 7 renders `<ol start="7">` as written. The task-list special-case is unchanged. Verified by rendering samples through marked 4.3.0.

Targets `main` so the release Action rebuilds the bundle on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)