### PR TITLE
Document branching/release workflow; update local setup to Altis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Want to contribute to H2? Fantastic. Here's some guidelines and tips to contribu
 
 ## Local setup
 
-H2 is a React app as a WordPress theme. For full development, you'll need a WordPress development environment; [Chassis](https://chassis.io/) is a good choice.
+H2 is a React app delivered as a WordPress theme. For full development you need a WordPress environment running H2; we use [Altis Local Server](https://www.altis-dxp.com/local-server/), the Docker-backed environment the consuming sites (such as hmn.md) run on. Add H2 as a theme in an Altis project and activate it.
 
 H2 also comes with Storybook, which can be used for component design and development in isolation. This can be run locally without a WordPress install, and is recommended for design iteration.
 
@@ -29,7 +29,7 @@ This will give you a component-level view of the project.
 
 ### Theme setup
 
-H2 is a regular WordPress theme, so add it into a WordPress development environment as desired.
+H2 is a regular WordPress theme, so add it into your Altis project's themes and activate it as desired.
 
 To develop with live reloading, run:
 
@@ -42,6 +42,21 @@ npm start
 ```
 
 You may also wish to install the various plugins as noted in the README for testing further functionality such as emoji reactions.
+
+
+## Branching and releases
+
+H2 builds its own assets, and that build is automated – so there are branches you write to and a branch you leave alone.
+
+Work happens on `main`. Branch off `main`, open a PR back into it, get it reviewed. That's the whole loop for a source change.
+
+You never touch `release` directly – no commits, no PRs against it. It is generated. When something lands on `main`, a GitHub Action checks out `release`, resets its source to match `main`, runs `npm run build`, force-adds the compiled `build/` directory (which is otherwise gitignored), and force-pushes the result. So anything you commit to `release` by hand is gone the next time the Action runs.
+
+What that means in practice:
+
+- A source change only takes effect once it's on `main` and the Action has rebuilt `release`. Merging it straight into `release` does nothing useful – the build never runs, so the shipped bundle stays stale.
+- Projects consuming H2 (e.g. via Composer) pin a commit on `release`. To pick up a fix, bump that pin to a release commit the Action produced, not to a hand-made one.
+- The build runs on Node 12; see `.build-script`.
 
 
 ## Project structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ You never touch `release` directly – no commits, no PRs against it. It is gene
 What that means in practice:
 
 - A source change only takes effect once it's on `main` and the Action has rebuilt `release`. Merging it straight into `release` does nothing useful – the build never runs, so the shipped bundle stays stale.
-- Projects consuming H2 (e.g. via Composer) pin a commit on `release`. To pick up a fix, bump that pin to a release commit the Action produced, not to a hand-made one.
+- Projects consuming H2 (e.g. via Composer) pin a commit on `release`. To pick up a fix, bump that pin to point to the latest [Action-generated] release branch commit.
 - The build runs on Node 12; see `.build-script`.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ You may also wish to install the various plugins as noted in the README for test
 
 ## Branching and releases
 
-H2 builds its own assets, and that build is automated – so there are branches you write to and a branch you leave alone.
+H2 builds its own assets into a releasable branch, and that build is automated. `main` should only be updated via pull request, and `release` should never be updated manually or used at the target for pull requests.
 
 Work happens on `main`. Branch off `main`, open a PR back into it, get it reviewed. That's the whole loop for a source change.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ H2 builds its own assets into a releasable branch, and that build is automated. 
 
 Work happens on `main`. Branch off `main`, open a PR back into it, get it reviewed. That's the whole loop for a source change.
 
-You never touch `release` directly – no commits, no PRs against it. It is generated. When something lands on `main`, a GitHub Action checks out `release`, resets its source to match `main`, runs `npm run build`, force-adds the compiled `build/` directory (which is otherwise gitignored), and force-pushes the result. So anything you commit to `release` by hand is gone the next time the Action runs.
+Never touch `release` directly – no commits, no PRs against it. It is generated. When something lands on `main`, a GitHub Action checks out `release`, resets its source to match `main`, runs `npm run build`, force-adds the compiled `build/` directory (which is otherwise gitignored), and force-pushes the result. So anything you commit to `release` by hand is gone the next time the Action runs.
 
 What that means in practice:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ This will give you a component-level view of the project.
 
 ### Theme setup
 
-H2 is a regular WordPress theme, so add it into your Altis project's themes and activate it as desired.
+H2 is a regular WordPress theme, so add it into your WordPress project's themes and activate it as desired.
 
 To develop with live reloading, run:
 


### PR DESCRIPTION
CONTRIBUTING didn't say anything about how releases are built, and that gap caught me out: I put a source fix straight into the `release` branch, which does nothing useful, because `release` is rebuilt by a GitHub Action on every push to `main` – merging into `release` skips the build, so the shipped bundle just stays stale.

So this adds a "Branching and releases" section that spells that out:

- Work on `main`; branch off it, PR back into it.
- Never commit to or PR against `release` – it's generated, and a hand-made commit there is overwritten by the next rebuild.
- The Action resets `release`'s source to `main`, builds, force-adds the gitignored `build/`, and force-pushes.
- Consumers pin a `release` commit the Action produced, not a hand-made one.

While I was in there I also replaced the Chassis reference in local setup with Altis Local Server, which is what we actually use now. I left the `@rmccue` keys note and the Node 12 build reference alone, and I didn't document `develop`, since it's effectively `main`-only these days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)